### PR TITLE
feat: initial nextjs upload app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# file-update
+# File Upload App
+
+Minimal Next.js 14 app that uploads a single CSV or XLSX file to Vercel Blob and notifies an n8n webhook.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Deployment
+
+Can be deployed to Vercel with no extra configuration.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,9 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  experimental: {
+    serverComponentsExternalPackages: ['busboy']
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "file-upload-app",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@vercel/blob": "^0.12.3",
+    "busboy": "^1.6.0",
+    "next": "14.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.24",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "eslint": "^8.56.0",
+    "eslint-config-next": "14.1.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import Busboy from 'busboy';
+import { Readable } from 'stream';
+import { put } from '@vercel/blob';
+import { getFileType } from '@/lib/fileType';
+
+export const runtime = 'nodejs';
+
+export async function POST(req: NextRequest) {
+  return await new Promise<NextResponse>((resolve, reject) => {
+    const bb = Busboy({ headers: Object.fromEntries(req.headers) });
+    let filename = '';
+    let mimeType = '';
+    const chunks: Buffer[] = [];
+
+    bb.on('file', (_name, stream, info) => {
+      filename = info.filename;
+      mimeType = info.mimeType;
+      stream.on('data', (data) => chunks.push(data));
+    });
+
+    bb.on('finish', async () => {
+      try {
+        const buffer = Buffer.concat(chunks);
+        const { url } = await put(filename, buffer, { access: 'public' });
+        const fileType = getFileType(mimeType, filename);
+
+        fetch('https://example.n8n.cloud/webhook/uploads', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url, filename, fileType })
+        }).catch((err) => console.error('Webhook error', err));
+
+        resolve(NextResponse.json({ success: true, url, fileType }));
+      } catch (err) {
+        reject(err);
+      }
+    });
+
+    bb.on('error', (err) => reject(err));
+
+    if (req.body) {
+      Readable.fromWeb(req.body as any).pipe(bb);
+    } else {
+      reject(new Error('No body'));
+    }
+  });
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,24 @@
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+}
+
+.dropzone {
+  border: 2px dashed #999;
+  padding: 2rem;
+  text-align: center;
+  cursor: pointer;
+}
+
+.file-info {
+  margin-top: 1rem;
+}
+
+.status {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  background: #eee;
+  margin-left: 0.5rem;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,15 @@
+import './globals.css';
+import type { ReactNode } from 'react';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'File Upload'
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useState, DragEvent, ChangeEvent } from 'react';
+
+interface FileState {
+  file: File;
+  status: 'idle' | 'uploading' | 'done';
+}
+
+export default function Home() {
+  const [state, setState] = useState<FileState | null>(null);
+
+  const upload = async (file: File) => {
+    setState({ file, status: 'uploading' });
+    const data = new FormData();
+    data.append('file', file);
+    await fetch('/api/upload', { method: 'POST', body: data });
+    setState({ file, status: 'done' });
+  };
+
+  const onDrop = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files[0];
+    if (file) upload(file);
+  };
+
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) upload(file);
+  };
+
+  return (
+    <main style={{ display: 'flex', minHeight: '100vh', justifyContent: 'center', alignItems: 'center' }}>
+      <div>
+        <div
+          className="dropzone"
+          onDragOver={(e) => e.preventDefault()}
+          onDrop={onDrop}
+        >
+          <input type="file" accept=".csv,.xlsx" onChange={onChange} />
+          <p>Drag and drop a file, or click to select</p>
+        </div>
+        {state && (
+          <div className="file-info">
+            {state.file.name} ({(state.file.size / 1024).toFixed(1)} KB)
+            <span className="status">
+              {state.status === 'uploading' ? 'Uploading…' : 'Done'}
+            </span>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/lib/fileType.ts
+++ b/src/lib/fileType.ts
@@ -1,0 +1,8 @@
+export function getFileType(mime: string, name: string): 'csv' | 'xlsx' | 'unknown' {
+  if (mime === 'text/csv') return 'csv';
+  if (mime === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet') return 'xlsx';
+  const ext = name.split('.').pop()?.toLowerCase();
+  if (ext === 'csv') return 'csv';
+  if (ext === 'xlsx') return 'xlsx';
+  return 'unknown';
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js 14 project with TypeScript config
- add drag-and-drop page to upload CSV/XLSX files and show status
- implement Busboy API route saving to Vercel Blob and notifying webhook

## Testing
- `npm install` *(fails: 403 Forbidden registry access)*
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68928ae7ce1083299ec42abe41c56eef